### PR TITLE
Fill in the missing code to coordinator initializers

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -611,6 +611,7 @@ public extension CollectionCoordinator {
     ///   - sections: The sections associated with this coordinator
     convenience init(collectionView: UICollectionView, sections: Section...) {
         let provider = ComposedSectionProvider()
+        sections.forEach(provider.append(_:))
         self.init(collectionView: collectionView, sectionProvider: provider)
     }
 

--- a/Sources/ComposedUI/StackView/StackCoordinator.swift
+++ b/Sources/ComposedUI/StackView/StackCoordinator.swift
@@ -136,3 +136,17 @@ extension StackCoordinator: SectionProviderMappingDelegate {
     public func mapping(_ mapping: SectionProviderMapping, deselect indexPath: IndexPath) { }
 
 }
+
+public extension StackCoordinator {
+
+    /// A convenience initializer that allows creation without a provider
+    /// - Parameters:
+    ///   - composedView: The `ComposedView` associated with this coordinator
+    ///   - sections: The sections associated with this coordinator
+    convenience init(composedView: ComposedView, sections: Section...) {
+        let provider = ComposedSectionProvider()
+        sections.forEach(provider.append(_:))
+        self.init(composedView: composedView, sectionProvider: provider)
+    }
+
+}

--- a/Sources/ComposedUI/TableView/TableCoordinator.swift
+++ b/Sources/ComposedUI/TableView/TableCoordinator.swift
@@ -669,6 +669,7 @@ public extension TableCoordinator {
     ///   - sections: The sections associated with this coordinator
     convenience init(tableView: UITableView, sections: Section...) {
         let provider = ComposedSectionProvider()
+        sections.forEach(provider.append(_:))
         self.init(tableView: tableView, sectionProvider: provider)
     }
 


### PR DESCRIPTION
I think the `CollectionCoordinator` and `TableCoordinator` had missed some codes in initializers, therefore I have completed it .
I also add convenience initializer to `StackCoordinator`.