### PR TITLE
Fix index-out-of-range crash on didEndDisplaying method calls

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -382,7 +382,7 @@ extension CollectionCoordinator: UICollectionViewDataSource {
             originalDelegate?.collectionView?(collectionView, didEndDisplaying: cell, forItemAt: indexPath)
         }
 
-        guard indexPath.section > sectionProvider.numberOfSections else { return }
+        guard indexPath.section < sectionProvider.numberOfSections else { return }
         let elements = elementsProvider(for: indexPath.section)
         let section = mapper.provider.sections[indexPath.section]
         elements.cell.didDisappear(cell, indexPath.item, section)
@@ -454,7 +454,7 @@ extension CollectionCoordinator: UICollectionViewDataSource {
             originalDelegate?.collectionView?(collectionView, didEndDisplayingSupplementaryView: view, forElementOfKind: elementKind, at: indexPath)
         }
 
-        guard indexPath.section > sectionProvider.numberOfSections else { return }
+        guard indexPath.section < sectionProvider.numberOfSections else { return }
         let elements = elementsProvider(for: indexPath.section)
         let section = mapper.provider.sections[indexPath.section]
 

--- a/Sources/ComposedUI/TableView/TableCoordinator.swift
+++ b/Sources/ComposedUI/TableView/TableCoordinator.swift
@@ -336,7 +336,7 @@ extension TableCoordinator: UITableViewDataSource {
             originalDelegate?.tableView?(tableView, didEndDisplayingHeaderView: view, forSection: section)
         }
 
-        guard section < sectionProvider.sections else { return }
+        guard section < sectionProvider.numberOfSections else { return }
         let elements = elementsProvider(for: section)
         let s = mapper.provider.sections[section]
         elements.header?.didDisappear(view, section, s)

--- a/Sources/ComposedUI/TableView/TableCoordinator.swift
+++ b/Sources/ComposedUI/TableView/TableCoordinator.swift
@@ -336,6 +336,7 @@ extension TableCoordinator: UITableViewDataSource {
             originalDelegate?.tableView?(tableView, didEndDisplayingHeaderView: view, forSection: section)
         }
 
+        guard section < sectionProvider.sections else { return }
         let elements = elementsProvider(for: section)
         let s = mapper.provider.sections[section]
         elements.header?.didDisappear(view, section, s)
@@ -414,7 +415,7 @@ extension TableCoordinator: UITableViewDataSource {
             originalDelegate?.tableView?(tableView, didEndDisplaying: cell, forRowAt: indexPath)
         }
 
-        guard indexPath.section > sectionProvider.numberOfSections else { return }
+        guard indexPath.section < sectionProvider.numberOfSections else { return }
         let elements = elementsProvider(for: indexPath.section)
         let section = mapper.provider.sections[indexPath.section]
         elements.cell.didDisappear(cell, indexPath.item, section)


### PR DESCRIPTION
I often get crashes at the `elementsProvider` call in `didEndDisplaying` methods when I tried to remove lots of sections in a section provider. The guard assertions in `didEndDisplaying` methods are (I suppose) meant to be making sure the `section` is still managed by the section provider. So the logic should be `less than` instead of `greater than`.

The modification does eliminate the crashing issue as I manipulate section providers. Hopefully it doesn't break anything and could be reviewed and merged. 😀 