### PR TITLE
Allow multiple cell types per section

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionSection.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionSection.swift
@@ -8,6 +8,10 @@ open class CollectionSection: CollectionElementsProvider {
     /// The cell configuration element
     public let cell: CollectionCellElement<UICollectionViewCell>
 
+    public var uniqueCells: [(dequeueMethod: DequeueMethod<UICollectionViewCell>, resuseIdentifier: String)] {
+        [(cell.dequeueMethod, cell.reuseIdentifier)]
+    }
+
     /// The header configuration element
     public let header: CollectionSupplementaryElement<UICollectionReusableView>?
 
@@ -98,6 +102,10 @@ open class CollectionSection: CollectionElementsProvider {
             } else {
                 self.footer = nil
             }
+    }
+
+    public func cellForIndex(_ index: Int) -> CollectionCellElement<UICollectionViewCell> {
+        return cell
     }
 
 }

--- a/Sources/ComposedUI/CollectionView/CollectionSectionProvider.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionSectionProvider.swift
@@ -2,7 +2,7 @@ import UIKit
 import Composed
 
 /// Provides a section to a collection view. Conform to this protool to use your section with a `UICollectionView`
-public protocol CollectionSectionProvider: Section {
+public protocol CollectionSectionProvider: CollectionElementsProviderProvider {
 
     /// Return a section cofiguration for the collection view.
     /// - Parameter traitCollection: The trait collection being applied to the view
@@ -10,11 +10,28 @@ public protocol CollectionSectionProvider: Section {
 
 }
 
-internal protocol CollectionElementsProvider {
-    var cell: CollectionCellElement<UICollectionViewCell> { get }
+extension CollectionSectionProvider {
+    public func collectionElementsProvider(with traitCollection: UITraitCollection) -> CollectionElementsProvider {
+        return section(with: traitCollection)
+    }
+}
+
+/// Provides a section to a collection view. Conform to this protool to use your section with a `UICollectionView`
+public protocol CollectionElementsProviderProvider: Section {
+
+    /// Return an elements provider for the collection view.
+    /// - Parameter traitCollection: The trait collection being applied to the view
+    func collectionElementsProvider(with traitCollection: UITraitCollection) -> CollectionElementsProvider
+
+}
+
+public protocol CollectionElementsProvider {
+    var uniqueCells: [(dequeueMethod: DequeueMethod<UICollectionViewCell>, resuseIdentifier: String)] { get }
     var header: CollectionSupplementaryElement<UICollectionReusableView>? { get }
     var footer: CollectionSupplementaryElement<UICollectionReusableView>? { get }
     var numberOfElements: Int { get }
+
+    func cellForIndex(_ index: Int) -> CollectionCellElement<UICollectionViewCell>
 }
 
 extension CollectionElementsProvider {


### PR DESCRIPTION
Sometimes it's useful to have multiple different cell types within a single section, for example to use sticky headers or to reduce to need for many layers of composition (which can be tricky to get animation right for).

This isn't a breaking change for consumers.

I think some of the naming should be improved if this were to be merged.

Draft because I want feedback on the impact of the feature itself rather than specifically the code.