### PR TITLE
Fix crash when performing update while animating

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -221,7 +221,7 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
 
     public func mappingDidEndUpdating(_ mapping: SectionProviderMapping) {
         assert(Thread.isMainThread)
-        collectionView.performBatchUpdates({
+        collectionView.performBatchUpdates {
             if defersUpdate {
                 prepareSections()
             }
@@ -233,10 +233,9 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
             sectionRemoves.forEach { $0() }
             sectionInserts.forEach { $0() }
             sectionUpdates.forEach { $0() }
-        }, completion: { [weak self] _ in
-            self?.reset()
-            self?.defersUpdate = false
-        })
+            reset()
+            defersUpdate = false
+        }
     }
 
     public func mapping(_ mapping: SectionProviderMapping, didUpdateSections sections: IndexSet) {


### PR DESCRIPTION
The `completion` block is called when the animation has completed, but at the end of the `updates` block the data has already been updated (from the perspective of the `UICollectionView`).

Not calling `reset()` and setting `defersUpdate = false` could cause crashes e.g. due to changes being applied multiple times.

The best way to recreate this is to have a series of updates occur very close to each other but with the "Slow Animation" setting enabled in the simulator.

This change might also apply to table views, I have not checked.

The crash would often be along the lines of "Tried to delete section at index 11 but there were only 11 sections" or would occur in `elementsProvider(for:)` with the error `"No UI configuration available for section 11"` when performing a non-data change e.g. a reload of a section