### PR TITLE
Enable/disable context menus per element

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -482,8 +482,9 @@ extension CollectionCoordinator {
     // MARK: - Context Menus
 
     public func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let cell = collectionView.cellForItem(at: indexPath),
-            let provider = mapper.provider.sections[indexPath.section] as? CollectionContextMenuHandler else { return nil }
+        guard let provider = mapper.provider.sections[indexPath.section] as? CollectionContextMenuHandler,
+            provider.allowsContextMenu(forElementAt: indexPath.item),
+            let cell = collectionView.cellForItem(at: indexPath) else { return nil }
         let preview = provider.contextMenu(previewForElementAt: indexPath.item, cell: cell)
         return UIContextMenuConfiguration(identifier: indexPath.string, previewProvider: preview) { suggestedElements in
             return provider.contextMenu(forElementAt: indexPath.item, cell: cell, suggestedActions: suggestedElements)

--- a/Sources/ComposedUI/CollectionView/Handlers/CollectionContextMenuHandler.swift
+++ b/Sources/ComposedUI/CollectionView/Handlers/CollectionContextMenuHandler.swift
@@ -5,6 +5,8 @@ import Composed
 @available(iOS 13.0, *)
 public protocol CollectionContextMenuHandler: CollectionSectionProvider {
 
+    func allowsContextMenu(forElementAt index: Int) -> Bool
+
     /// Return a `UIMenu` representing the actions that should be shown for the specified cell.
     /// - Parameters:
     ///   - index: The index of the element
@@ -41,6 +43,7 @@ public protocol CollectionContextMenuHandler: CollectionSectionProvider {
 
 @available(iOS 13.0, *)
 public extension CollectionContextMenuHandler {
+    func allowsContextMenu(forElementAt index: Int) -> Bool { return true }
     func contextMenu(forElementAt index: Int, cell: UICollectionViewCell, suggestedActions: [UIMenuElement]) -> UIMenu? { return nil }
     func contextMenu(previewForElementAt index: Int, cell: UICollectionViewCell) -> UIContextMenuContentPreviewProvider? { return nil }
     func contextMenu(previewForHighlightingElementAt index: Int, cell: UICollectionViewCell) -> UITargetedPreview? { return nil }

--- a/Sources/ComposedUI/CollectionView/Handlers/CollectionContextMenuHandler.swift
+++ b/Sources/ComposedUI/CollectionView/Handlers/CollectionContextMenuHandler.swift
@@ -5,6 +5,8 @@ import Composed
 @available(iOS 13.0, *)
 public protocol CollectionContextMenuHandler: CollectionSectionProvider {
 
+    /// Specifies whether or not a specific element allows showing a context menu. If you want UIKit to indicate that a menu is usually provided for this element, true `true` and simply return `nil` for `contextMenu(forElementAt:cell:suggestedActions:)`
+    /// - Parameter index: The index of the element
     func allowsContextMenu(forElementAt index: Int) -> Bool
 
     /// Return a `UIMenu` representing the actions that should be shown for the specified cell.

--- a/Sources/ComposedUI/TableView/Handlers/TableContextMenuHandler.swift
+++ b/Sources/ComposedUI/TableView/Handlers/TableContextMenuHandler.swift
@@ -5,6 +5,10 @@ import Composed
 @available(iOS 13.0, *)
 public protocol TableContextMenuHandler: TableSectionProvider {
 
+    /// Specifies whether or not a specific element allows showing a context menu. If you want UIKit to indicate that a menu is usually provided for this element, true `true` and simply return `nil` for `contextMenu(forElementAt:cell:suggestedActions:)`
+    /// - Parameter index: The index of the element
+    func allowsContextMenu(forElementAt index: Int) -> Bool
+
     /// Return a `UIMenu` representing the actions that should be shown for the specified cell.
     /// - Parameters:
     ///   - index: The index of the element

--- a/Sources/ComposedUI/TableView/Handlers/TableContextMenuHandler.swift
+++ b/Sources/ComposedUI/TableView/Handlers/TableContextMenuHandler.swift
@@ -45,6 +45,7 @@ public protocol TableContextMenuHandler: TableSectionProvider {
 
 @available(iOS 13.0, *)
 public extension TableContextMenuHandler {
+    func allowsContextMenu(forElementAt index: Int) -> Bool { return true }
     func contextMenu(forElementAt index: Int, cell: UITableViewCell, suggestedActions: [UIMenuElement]) -> UIMenu? { return nil }
     func contextMenu(previewForElementAt index: Int, cell: UITableViewCell) -> UIContextMenuContentPreviewProvider? { return nil }
     func contextMenu(previewForHighlightingElementAt index: Int, cell: UITableViewCell) -> UITargetedPreview? { return nil }

--- a/Sources/ComposedUI/TableView/TableCoordinator.swift
+++ b/Sources/ComposedUI/TableView/TableCoordinator.swift
@@ -436,9 +436,10 @@ extension TableCoordinator {
     // MARK: - Context Menus
 
     open func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let cell = tableView.cellForRow(at: indexPath),
-            let provider = mapper.provider.sections[indexPath.section] as? TableContextMenuHandler else {
-                return originalDelegate?.tableView?(tableView, contextMenuConfigurationForRowAt: indexPath, point: point) ?? nil
+        guard let provider = mapper.provider.sections[indexPath.section] as? TableContextMenuHandler,
+              provider.allowsContextMenu(forElementAt: indexPath.item),
+              let cell = tableView.cellForRow(at: indexPath) else {
+            return originalDelegate?.tableView?(tableView, contextMenuConfigurationForRowAt: indexPath, point: point) ?? nil
         }
 
         let preview = provider.contextMenu(previewForElementAt: indexPath.item, cell: cell)


### PR DESCRIPTION
Without this change, currently if you've conformed to the protocol, long pressing will still make an attempt to show a context menu, even if you return an empty configuration. This results in a poorer UX.

The included API addition allows you to selectively disable the long press gesture (essentially) on a per element basis.