### PR TITLE
Fix swift 5.2 compiling

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/composed-swift/composed",
         "state": {
           "branch": null,
-          "revision": "42aaf908c4ffdb9becb5eae458390c6e4b1ca323",
-          "version": "1.0.1"
+          "revision": "8dcf1fbbc1a23f7e2b9e0e09f6126f12469e8d80",
+          "version": "1.0.4"
         }
       }
     ]

--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -221,7 +221,7 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
 
     public func mappingDidEndUpdating(_ mapping: SectionProviderMapping) {
         assert(Thread.isMainThread)
-        collectionView.performBatchUpdates {
+        collectionView.performBatchUpdates({
             if defersUpdate {
                 prepareSections()
             }
@@ -235,7 +235,7 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
             sectionUpdates.forEach { $0() }
             reset()
             defersUpdate = false
-        }
+        })
     }
 
     public func mapping(_ mapping: SectionProviderMapping, didUpdateSections sections: IndexSet) {


### PR DESCRIPTION
Introduced in #9. #12 adds GitHub actions to ensure this doesn't occur again.