### PR TITLE
Potential fix for invalidation crashes

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -217,6 +217,13 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
     public func mappingWillBeginUpdating(_ mapping: SectionProviderMapping) {
         reset()
         defersUpdate = true
+
+        // This is called here to ensure that the collection view's internal state is in-sync with the state of the
+        // data in hierarchy of sections. If this is not done it can cause various crashes when `performBatchUpdates` is called
+        // due to the collection view requesting data for sections that no longer exist, or crashes because the collection view is
+        // told to delete/insert from/into sections that it does not yet think exist.
+        //
+        // For more information on this see https://github.com/composed-swift/ComposedUI/pull/14
         collectionView.layoutIfNeeded()
     }
 

--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -217,6 +217,7 @@ extension CollectionCoordinator: SectionProviderMappingDelegate {
     public func mappingWillBeginUpdating(_ mapping: SectionProviderMapping) {
         reset()
         defersUpdate = true
+        collectionView.layoutIfNeeded()
     }
 
     public func mappingDidEndUpdating(_ mapping: SectionProviderMapping) {


### PR DESCRIPTION
As mentioned in https://github.com/composed-swift/ComposedUI/issues/13 and https://github.com/composed-swift/ComposedUI/issues/8 there are some scenarios where the collection view’s data is out-of-sync with the data in composed.

As mentioned in https://github.com/composed-swift/ComposedUI/issues/13 calling `layoutIfNeeded` can trigger the data to be in sync again. In this I have added it to `mappingWillBeginUpdating(_:)` which _appears_ to solve the problem.

It might be needed in `replace(sectionProvider:)` (because `reloadData` is called) and/or `mappingDidInvalidate(_:)` (for the same reason) but I’m still investigating.

I have validated this fix against https://github.com/composed-swift/ComposedUI/issues/8 and it fixes the crash.

https://github.com/composed-swift/ComposedUI/issues/13 still needs to be investigated and may require `layoutIfNeeded` to be called in `mappingDidInvalidate`. Marking as a draft until this is checked.